### PR TITLE
Add additional Supervisor endpoints

### DIFF
--- a/ui/src/api/SupervisorRequests.ts
+++ b/ui/src/api/SupervisorRequests.ts
@@ -5,11 +5,32 @@ import expressApi from 'axios'
 const apiPath = '/supervisor' as string
 
 export const supervisorRequests = {
-  host_config(newHostname: string) {
+  applications_state() {
     return expressApi.post(apiPath, {
-      type: 'PATCH',
-      path: 'v1/device/host-config',
-      params: { network: { hostname: newHostname } }
+      type: 'GET',
+      path: 'v2/applications/state',
+      params: false
+    })
+  },
+  blink() {
+    return expressApi.post(apiPath, {
+      type: 'POST',
+      path: 'v1/blink',
+      params: false
+    })
+  },
+  cleanup_volumes() {
+    return expressApi.post(apiPath, {
+      type: 'GET',
+      path: 'v2/cleanup-volumes',
+      params: false
+    })
+  },
+  containerId() {
+    return expressApi.post(apiPath, {
+      type: 'GET',
+      path: 'v2/containerId',
+      params: false
     })
   },
   device() {
@@ -19,11 +40,95 @@ export const supervisorRequests = {
       params: false
     })
   },
+  device_host_config_get() {
+    return expressApi.post(apiPath, {
+      type: 'GET',
+      path: 'v1/device/host-config',
+      params: false
+    })
+  },
+  device_host_config_patch(data: unknown) {
+    return expressApi.post(apiPath, {
+      type: 'PATCH',
+      path: 'v1/device/host-config',
+      params: data
+    })
+  },
+  device_name() {
+    return expressApi.post(apiPath, {
+      type: 'GET',
+      path: 'v2/device/name',
+      params: false
+    })
+  },
+  device_tags() {
+    return expressApi.post(apiPath, {
+      type: 'GET',
+      path: 'v2/device/tags',
+      params: false
+    })
+  },
+  device_vpn() {
+    return expressApi.post(apiPath, {
+      type: 'GET',
+      path: 'v2/device/vpn',
+      params: false
+    })
+  },
+  healthy() {
+    return expressApi.post(apiPath, {
+      type: 'GET',
+      path: 'v1/healthy',
+      params: false
+    })
+  },
+  journald_logs() {
+    return expressApi.post(apiPath, {
+      type: 'POST',
+      path: 'v2/local/logs',
+      params: { follow: false, all: true }
+    })
+  },
+  local_device_info() {
+    return expressApi.post(apiPath, {
+      type: 'GET',
+      path: 'v2/local/device-info',
+      params: false
+    })
+  },
+  local_logs() {
+    return expressApi.post(apiPath, {
+      type: 'GET',
+      path: 'v2/local/logs',
+      params: false
+    })
+  },
+  local_target_state_get() {
+    return expressApi.post(apiPath, {
+      type: 'GET',
+      path: 'v2/local/target-state',
+      params: false
+    })
+  },
+  local_target_state_post(targetState: unknown) {
+    return expressApi.post(apiPath, {
+      type: 'POST',
+      path: 'v2/local/target-state',
+      params: targetState
+    })
+  },
   ping() {
     return expressApi.post(apiPath, {
       type: 'GET',
       path: 'ping',
       params: false
+    })
+  },
+  purge(appId: number) {
+    return expressApi.post(apiPath, {
+      type: 'POST',
+      path: 'v1/purge',
+      params: { appId: appId }
     })
   },
   reboot(force: boolean) {
@@ -33,15 +138,34 @@ export const supervisorRequests = {
       params: { force: force }
     })
   },
+  regenerate_api_key() {
+    return expressApi.post(apiPath, {
+      type: 'POST',
+      path: 'v1/regenerate-api-key'
+    })
+  },
+  restart(appId: number) {
+    return expressApi.post(apiPath, {
+      type: 'POST',
+      path: 'v1/restart',
+      params: { appId: appId }
+    })
+  },
   shutdown(force: boolean) {
     return expressApi.post(apiPath, {
       type: 'POST',
-      path: '/v1/shutdown',
+      path: 'v1/shutdown',
       params: { force: force }
     })
   },
+  state_status() {
+    return expressApi.post(apiPath, {
+      type: 'GET',
+      path: 'v2/state/status',
+      params: false
+    })
+  },
   update(force: boolean) {
-    // This route will return a 404 in development mode as it won't exist
     return expressApi.post(apiPath, {
       type: 'GET',
       path: 'v1/update',
@@ -52,6 +176,13 @@ export const supervisorRequests = {
     return expressApi.post(apiPath, {
       type: 'GET',
       path: 'v1/blink',
+      params: false
+    })
+  },
+  version() {
+    return expressApi.post(apiPath, {
+      type: 'GET',
+      path: 'v2/version',
       params: false
     })
   }

--- a/ui/src/components/ChangeHostname.vue
+++ b/ui/src/components/ChangeHostname.vue
@@ -32,7 +32,9 @@ export default defineComponent({
     const response = ref<AxiosResponse>()
 
     async function changeHostname(newHostname: string) {
-      response.value = await supervisorRequests.host_config(newHostname)
+      response.value = await supervisorRequests.device_host_config_patch({
+        network: { hostname: newHostname }
+      })
     }
     return {
       changeHostname,


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Added additional endpoints for interaction with the supervisor. 

**Is there anything you'd like reviewers to focus on?**

These have **not yet been tested** because I don't have hardware to run it on right now. Hopefully you can send some test API requests to each endpoint and check for any errors.

There are some endpoints that I did not add. That is because for the most part the endpoints receive a payload with data on various parameters, but on other occasions, the data is received as part of the URL, which would require writing something new to handle URL manipulation. Fortunately the url manipulation way of passing data seem rare, seem mostly related to older endpoints for single container fleets, and do not provide much functionality that can't be gained from reading the JSON of other endpoints, so have left them off for. Can always revisit if you come across some pressing need for one of them.

The change to the hostname endpoint is because it turns out that the endpoint doesn't just change the hostname, it can also change some proxy settings, so passed that option back to the Vue frontend to decide. 

