### PR TITLE
Auto identify bridge network ip address for wifi-connect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 *.ntvs*
 *.njsproj
 *.sln
+
+# Development components
+wifi/

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -60,4 +60,8 @@ COPY --from=ejs-ui-build /build-context/dist .
 # Copy UI in to container 
 COPY --from=ui-build-step /build-context/dist/spa ./public
 
-CMD ["node", "index.js"]
+# Copy startup scripts
+COPY scripts .
+
+# Run the start script
+CMD ["sh", "start.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,11 +17,11 @@ services:
   py-wifi-connect:
     environment:
       ## Listening IP and port ##
-      PWC_HOST: "172.17.0.1"
+      PWC_HOST: bridge
       PWC_PORT: 9090
 
       ## Hotspot details ##
-      PWC_HOTSPOT_SSID: "Py Wi-Fi Connect"
+      PWC_HOTSPOT_SSID: "Balena Device UI"
 
       ## Required system variables ##
       DBUS_SYSTEM_BUS_ADDRESS: "unix:path=/host/run/dbus/system_bus_socket"

--- a/expressjs/src/routes/WifiConnect.ts
+++ b/expressjs/src/routes/WifiConnect.ts
@@ -8,7 +8,8 @@ const router = express.Router()
 // Set Axios defaults
 const wifiAxios = axios.create({ timeout: 15000 })
 wifiAxios.defaults.baseURL =
-  process.env.WIFI_CONNECT_BASEURL || 'http://172.17.0.1:9090/'
+  process.env.WIFI_CONNECT_BASEURL ||
+  `http://${process.env.BRIDGE_NETWORK_IP}:9090/`
 
 router.get('/internet_check', function (_req, res) {
   Logger.debug('Running internet connectivity check.')

--- a/scripts/.env_vars
+++ b/scripts/.env_vars
@@ -1,0 +1,4 @@
+#!/usr/bin/env
+
+# Exports the current bridge network IP address
+export BRIDGE_NETWORK_IP=$(ip route | awk '/default / { print $3 }')

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env
+
+# Import env variables
+. .env_vars
+
+# Execute node
+exec node index.js


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Published a new release of py-wifi-connect with the ability to identify the current bridge IP address and to specify that IP address as the IP to listen on. Then added the functionality to use it in to the Balena-Device-UI in this pull request. 

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**

