### PR TITLE
Fix internet check endpoint

### DIFF
--- a/expressjs/src/routes/WifiConnectRoutes.ts
+++ b/expressjs/src/routes/WifiConnectRoutes.ts
@@ -13,12 +13,14 @@ wifiAxios.defaults.baseURL =
 
 // -- Routes -- //
 router.get('/internet_check', function (_req, res) {
-  Logger.debug('Running internet connectivity check.')
-  dns.lookup('google.com', function (err) {
-    if (err && err.code == 'ENOTFOUND') {
+  dns.lookupService('8.8.8.8', 53, function (err) {
+    if (err === null) {
+      res.json({ internet: true })
+    } else if (err && err.code == 'ENOTFOUND') {
       res.json({ internet: false })
     } else {
-      res.json({ internet: true })
+      Logger.error(err)
+      throw new Error('Error checking internet connectivity.')
     }
   })
 })


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
There was an internet check endpoint put in while doing the wi-fi connect work, but ended up not being used. Turns out it may end up being useful for checking internet connectivity, but after testing it appeared to cache the response after first use, which is not much use for a device with a changing connectivity state. 

After working through some other solutions (https://stackoverflow.com/questions/15270902/check-for-internet-connectivity-in-nodejs) this one appears to work best. It is quick using a DNS resolution for Google (highly available) and in my tests has always responded correctly according to changing connectivity states (no caching). 
