### PR TITLE
adding mdns-advertise to docker-compose

### DIFF
--- a/balena.yml
+++ b/balena.yml
@@ -21,3 +21,7 @@ data:
     - raspberrypi3
     - raspberrypi3-64
     - raspberrypi4-64
+    - fincm3
+    - raspberrypi400-64
+    - intel-nuc
+    - genericx86-64-ext

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,17 @@ services:
       - NET_ADMIN
     privileged: true # This can be removed if you do not need the LED indicator.
 
+  mdns-advertise:
+    image: ghcr.io/nucleardreamer/mdns-advertise
+    restart: "always"
+    privileged: true
+    network_mode: host
+    labels:
+      io.balena.features.dbus: '1'
+    environment:
+      DBUS_SYSTEM_BUS_ADDRESS: 'unix:path=/host/run/dbus/system_bus_socket'
+      MDNS_TLD: 'balena.local'
+
 volumes:
   py_wifi_connect_db:
   storage:


### PR DESCRIPTION
Signed-off-by: Flynn Joffray <nucleardreamer@gmail.com>

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Added `mdns-advertise` to the `docker-compose.yml`

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**

This uses the [mdns-advertise](https://github.com/nucleardreamer/mdns-advertise) block to setup `http://balena.local/` as a URL to easily access the device locally, instead of remembering its IP address.

I do believe this is better to keep as a separate container and not incorporate into the main project, as it should be optional but still useful.