### PR TITLE
Add chart showing real-time CPU stats

### DIFF
--- a/expressjs/src/routes/v1/SystemRoutes.ts
+++ b/expressjs/src/routes/v1/SystemRoutes.ts
@@ -22,207 +22,360 @@ router.post('/v1/system/systeminfo', function (req, res) {
   if (req.body.cmd === 'a') {
     si.audio()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'b') {
     si.bios()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'B') {
     si.baseboard()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'C') {
     si.chassis()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'c') {
     si.cpu()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'd') {
     si.diskLayout()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'D') {
     si.disksIO()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'e') {
     si.blockDevices()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'E') {
     si.fsOpenFiles()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'f') {
     si.fsSize()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'F') {
     si.fsStats()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'g') {
     si.graphics()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'h') {
     si.bluetoothDevices()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'i') {
     si.inetLatency()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'I') {
     si.inetChecksite('https://systeminformation.io')
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'j') {
     si.cpuCurrentSpeed()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'l') {
     si.currentLoad()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'L') {
     si.fullLoad()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'm') {
     si.mem()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'M') {
     si.memLayout()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'o') {
     si.osInfo()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'p') {
     si.processes()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'P') {
     si.processLoad('postgres, login, apache, mysql, nginx, git, node')
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'r') {
     si.printer()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 's') {
     si.services('apache2, postgres, wsearch')
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'S') {
     si.shell()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'T') {
     si.cpuTemperature()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'u') {
     si.usb()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'U') {
     si.uuid()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'v') {
     si.versions()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'V') {
     si.vboxInfo()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'w') {
     si.wifiNetworks()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'W') {
     si.wifiInterfaces()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'x') {
     si.wifiConnections()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'y') {
     si.system()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'Y') {
     si.battery()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === 'z') {
     si.users()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === '1') {
     si.networkInterfaceDefault()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === '2') {
     si.networkGatewayDefault()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === '3') {
     si.networkInterfaces()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === '4') {
     si.networkStats()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === '5') {
     si.networkConnections()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === '6') {
     si.dockerInfo()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === '7') {
     si.dockerImages()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === '8') {
     si.dockerContainers(true)
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === '9') {
     si.dockerContainerStats('*')
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === '0') {
     si.dockerContainerProcesses('*')
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === '+') {
     si.dockerVolumes()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === ',') {
     si.getStaticData()
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === '.') {
     si.getDynamicData('apache2, postgres, wsearch')
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   } else if (req.body.cmd === '/') {
     si.getAllData('apache2, postgres, wsearch')
       .then((data) => res.json({ data }))
-      .catch((error) => res.json({ error }))
+      .catch((err) => {
+        Logger.error(err)
+        res.json({ err })
+      })
   }
 })
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,13 +13,15 @@
   },
   "dependencies": {
     "@quasar/extras": "^1.12.5",
+    "apexcharts": "^3.33.2",
     "axios": "^0.26.0",
     "core-js": "^3.21.0",
     "js-file-download": "^0.4.12",
     "quasar": "^2.5.5",
     "vue": "^3.0.0",
     "vue-i18n": "^9.0.0",
-    "vue-router": "^4.0.0"
+    "vue-router": "^4.0.0",
+    "vue3-apexcharts": "^1.4.1"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.17.0",

--- a/ui/quasar.conf.js
+++ b/ui/quasar.conf.js
@@ -28,7 +28,7 @@ module.exports = configure(function (ctx) {
     // app boot file (/src/boot)
     // --> boot files are part of "main.js"
     // https://quasar.dev/quasar-cli/boot-files
-    boot: ['axios', 'i18n', 'system'],
+    boot: ['apexcharts', 'axios', 'i18n', 'system'],
 
     // https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-css
     css: ['app.scss'],

--- a/ui/src/boot/apexcharts.ts
+++ b/ui/src/boot/apexcharts.ts
@@ -1,0 +1,7 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+import VueApexCharts from 'vue3-apexcharts'
+import { boot } from 'quasar/wrappers'
+
+export default boot(({ app }) => {
+  app.use(VueApexCharts)
+})

--- a/ui/src/components/charts/CpuStats.vue
+++ b/ui/src/components/charts/CpuStats.vue
@@ -1,9 +1,5 @@
 <template>
-  <apexchart
-    :height="props.height"
-    :options="chartOptions"
-    :series="series"
-  ></apexchart>
+  <apexchart :height="props.height" :options="chartOptions" :series="series" />
 </template>
 
 <script lang="ts">
@@ -33,6 +29,10 @@ export default defineComponent({
     height: {
       type: Number,
       default: 175
+    },
+    maxDataPoints: {
+      type: Number,
+      default: 20
     },
     pollInterval: {
       type: Number,
@@ -72,7 +72,6 @@ export default defineComponent({
       },
       stroke: {
         width: 2,
-        show: 'false',
         curve: 'smooth'
       },
       title: {
@@ -92,6 +91,9 @@ export default defineComponent({
         min: 0,
         max: 100,
         labels: {
+          formatter: function (val: number) {
+            return `${val}%`
+          },
           show: true
         }
       },
@@ -138,7 +140,7 @@ export default defineComponent({
           .then(async (res) => {
             // If there are more than 20 items in the object, remove one
             // to avoid it growing to big
-            if (series.value[0].data.length > 20) {
+            if (series.value[0].data.length > props.maxDataPoints) {
               series.value[0].data.shift()
             }
 

--- a/ui/src/components/charts/CpuStats.vue
+++ b/ui/src/components/charts/CpuStats.vue
@@ -1,11 +1,19 @@
 <template>
-  <apexchart :height="props.height" :options="chartOptions" :series="series" />
+  <div v-if="noData" class="text-center">
+    {{ $t('charts.cpu_stats.no_data') }}
+  </div>
+  <apexchart
+    v-else
+    :height="props.height"
+    :options="chartOptions"
+    :series="series"
+  />
 </template>
 
 <script lang="ts">
 import { AxiosResponse } from 'axios'
 import { expressApi } from 'boot/axios'
-import { getCssVar, useQuasar } from 'quasar'
+import { getCssVar } from 'quasar'
 import { defineComponent, onMounted, onUnmounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { LoadingBar } from 'quasar'
@@ -40,11 +48,11 @@ export default defineComponent({
     }
   },
   setup(props) {
-    const $q = useQuasar()
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const { t } = useI18n()
 
     // Constants
+    const noData = ref<boolean>(false)
     const series = ref<series>([{ name: 'CPU', data: ['0'] }])
     const unMounted = ref<boolean>(false)
 
@@ -154,9 +162,9 @@ export default defineComponent({
           })
           .catch(function (err) {
             console.log(err)
-            $q.notify({ type: 'negative', message: t('general.Error') })
 
             // On error, stop the polling
+            noData.value = true
             unMounted.value = true
           })
         if (unMounted.value) {
@@ -167,6 +175,7 @@ export default defineComponent({
 
     return {
       chartOptions,
+      noData,
       props,
       series
     }

--- a/ui/src/components/charts/CpuStats.vue
+++ b/ui/src/components/charts/CpuStats.vue
@@ -1,0 +1,173 @@
+<template>
+  <apexchart
+    :height="props.height"
+    :options="chartOptions"
+    :series="series"
+  ></apexchart>
+</template>
+
+<script lang="ts">
+import { AxiosResponse } from 'axios'
+import { expressApi } from 'boot/axios'
+import { getCssVar, useQuasar } from 'quasar'
+import { defineComponent, onMounted, onUnmounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { LoadingBar } from 'quasar'
+
+interface cpuStat {
+  data: {
+    currentLoad: number
+  }
+}
+
+interface series {
+  [index: number]: {
+    name: string
+    data: Array<string>
+  }
+}
+
+export default defineComponent({
+  name: 'IntCpuStats',
+  props: {
+    height: {
+      type: Number,
+      default: 175
+    },
+    pollInterval: {
+      type: Number,
+      default: 1500
+    }
+  },
+  setup(props) {
+    const $q = useQuasar()
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const { t } = useI18n()
+
+    // Constants
+    const series = ref<series>([{ name: 'CPU', data: ['0'] }])
+    const unMounted = ref<boolean>(false)
+
+    const chartOptions = ref({
+      chart: {
+        height: 'auto',
+        type: 'area',
+        tooltip: {
+          enabled: false
+        },
+        animations: {
+          enabled: false
+        },
+        toolbar: {
+          show: false
+        },
+        zoom: {
+          enabled: false
+        }
+      },
+      colors: [getCssVar('primary')],
+      tooltip: { enabled: false },
+      dataLabels: {
+        enabled: false
+      },
+      stroke: {
+        width: 2,
+        show: 'false',
+        curve: 'smooth'
+      },
+      title: {
+        text: t('charts.cpu_stats.cpu_status'),
+        align: 'left'
+      },
+      markers: {
+        size: 0
+      },
+      xaxis: {
+        type: 'category',
+        labels: {
+          show: false
+        }
+      },
+      yaxis: {
+        min: 0,
+        max: 100,
+        labels: {
+          show: true
+        }
+      },
+      legend: {
+        show: false
+      }
+    })
+
+    onMounted(() => {
+      // Disables the AJAX loading bar at the bottom of the page for polled system info requests
+      LoadingBar.setDefaults({
+        hijackFilter(url: string) {
+          return !url.includes('systeminfo')
+        }
+      })
+
+      // Start the polling
+      void fetchCpuStats()
+    })
+
+    onUnmounted(() => {
+      // Re-enables the AJAX loading bar at the bottom of the page for system info requests
+      LoadingBar.setDefaults({
+        hijackFilter() {
+          return true
+        }
+      })
+
+      // Instructs to exit the running poll loop, because this component is no longer visible
+      unMounted.value = true
+    })
+
+    // Functions
+    function delay(ms: number) {
+      return new Promise((resolve) => setTimeout(resolve, ms))
+    }
+
+    async function fetchCpuStats() {
+      for (;;) {
+        await expressApi
+          .post<AxiosResponse>('/v1/system/systeminfo', {
+            cmd: 'l'
+          })
+          .then(async (res) => {
+            // If there are more than 20 items in the object, remove one
+            // to avoid it growing to big
+            if (series.value[0].data.length > 20) {
+              series.value[0].data.shift()
+            }
+
+            // Fetch the data from the response
+            const cpuStat: cpuStat = res.data
+            // Add the fetched data in to the chart data
+            series.value[0].data.push(cpuStat.data.currentLoad.toFixed(0))
+
+            // Delay before calling next fetch
+            await delay(props.pollInterval)
+          })
+          .catch(function (err) {
+            console.log(err)
+            $q.notify({ type: 'negative', message: t('general.Error') })
+
+            // On error, stop the polling
+            unMounted.value = true
+          })
+        if (unMounted.value) {
+          return
+        }
+      }
+    }
+
+    return {
+      chartOptions,
+      props,
+      series
+    }
+  }
+})
+</script>

--- a/ui/src/components/system/DeviceInfo.vue
+++ b/ui/src/components/system/DeviceInfo.vue
@@ -20,7 +20,7 @@
         }}
       </q-chip>
     </h4>
-
+    <div><cpu-stats /></div>
     <div class="row items-start">
       <q-card flat bordered class="">
         <q-card-section horizontal>
@@ -143,12 +143,14 @@
 <script lang="ts">
 import { sdkRequests } from 'src/api/SdkRequests'
 import { AxiosError, AxiosResponse } from 'axios'
+import CpuStats from 'components/charts/CpuStats.vue'
 import { useQuasar } from 'quasar'
 import { internetConnectivity } from 'src/api/SystemRequests'
 import { defineComponent, ref, onMounted } from 'vue'
 
 export default defineComponent({
   name: 'IntDeviceInfoComponent',
+  components: { CpuStats },
   setup() {
     const loading = ref<boolean>(true)
     const $q = useQuasar()

--- a/ui/src/components/system/OfflineDeviceInfo.vue
+++ b/ui/src/components/system/OfflineDeviceInfo.vue
@@ -11,7 +11,7 @@
         }}
       </q-chip>
     </h4>
-
+    <div><cpu-stats /></div>
     <div class="row items-start">
       <q-card flat bordered class="">
         <q-card-section horizontal>
@@ -101,10 +101,11 @@
 <script lang="ts">
 import { AxiosError } from 'axios'
 import { expressApi } from 'boot/axios'
+import CpuStats from 'components/charts/CpuStats.vue'
 import { useQuasar } from 'quasar'
 import { supervisorRequests } from 'src/api/SupervisorRequests'
 import { internetConnectivity } from 'src/api/SystemRequests'
-import { defineComponent, ref, onMounted } from 'vue'
+import { defineComponent, onMounted, ref } from 'vue'
 
 interface device {
   current_release: string
@@ -136,6 +137,7 @@ interface m {
 
 export default defineComponent({
   name: 'IntOfflineDeviceInfoComponent',
+  components: { CpuStats },
   setup() {
     // Tools
     const loading = ref<boolean>(true)

--- a/ui/src/i18n/en-US/index.json
+++ b/ui/src/i18n/en-US/index.json
@@ -1,5 +1,10 @@
 {
   "Response": "Response",
+  "charts": {
+    "cpu_stats": {
+      "cpu_status": "CPU Status"
+    }
+  },
   "containers": {
     "Containers": "Containers"
   },

--- a/ui/src/i18n/en-US/index.json
+++ b/ui/src/i18n/en-US/index.json
@@ -2,7 +2,8 @@
   "Response": "Response",
   "charts": {
     "cpu_stats": {
-      "cpu_status": "CPU Status"
+      "cpu_status": "CPU Status",
+      "no_data": "Unable to fetch CPU data."
     }
   },
   "containers": {

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6352,11 +6352,6 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
-vue-apexcharts@^1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/vue-apexcharts/-/vue-apexcharts-1.6.2.tgz#0547826067f97e8ea67ca9423e524eb6669746ad"
-  integrity sha512-9HS3scJwWgKjmkcWIf+ndNDR0WytUJD8Ju0V2ZYcjYtlTLwJAf2SKUlBZaQTkDmwje/zMgulvZRi+MXmi+WkKw==
-
 vue-eslint-parser@^8.0.0, vue-eslint-parser@^8.0.1:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-8.3.0.tgz#5d31129a1b3dd89c0069ca0a1c88f970c360bd0d"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1835,6 +1835,18 @@ anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+apexcharts@^3.33.2:
+  version "3.33.2"
+  resolved "https://registry.yarnpkg.com/apexcharts/-/apexcharts-3.33.2.tgz#ebb186f1da954fc31857f1ee562a6b281d25db6b"
+  integrity sha512-GkHZ3o36ZT/jSBh5y1pxxRzwM3tvtladtkcUTfXwP0wYAHK8Qj0X4ZPsupP7emRIjhOVpGsCxW9xeO3F5w+AOQ==
+  dependencies:
+    svg.draggable.js "^2.2.2"
+    svg.easing.js "^2.0.0"
+    svg.filter.js "^2.0.2"
+    svg.pathmorphing.js "^0.1.3"
+    svg.resize.js "^1.4.3"
+    svg.select.js "^3.0.1"
+
 archiver-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/archiver-utils/-/archiver-utils-2.1.0.tgz#e8a460e94b693c3e3da182a098ca6285ba9249e2"
@@ -6004,6 +6016,61 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+svg.draggable.js@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/svg.draggable.js/-/svg.draggable.js-2.2.2.tgz#c514a2f1405efb6f0263e7958f5b68fce50603ba"
+  integrity sha512-JzNHBc2fLQMzYCZ90KZHN2ohXL0BQJGQimK1kGk6AvSeibuKcIdDX9Kr0dT9+UJ5O8nYA0RB839Lhvk4CY4MZw==
+  dependencies:
+    svg.js "^2.0.1"
+
+svg.easing.js@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/svg.easing.js/-/svg.easing.js-2.0.0.tgz#8aa9946b0a8e27857a5c40a10eba4091e5691f12"
+  integrity sha1-iqmUawqOJ4V6XEChDrpAkeVpHxI=
+  dependencies:
+    svg.js ">=2.3.x"
+
+svg.filter.js@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/svg.filter.js/-/svg.filter.js-2.0.2.tgz#91008e151389dd9230779fcbe6e2c9a362d1c203"
+  integrity sha1-kQCOFROJ3ZIwd5/L5uLJo2LRwgM=
+  dependencies:
+    svg.js "^2.2.5"
+
+svg.js@>=2.3.x, svg.js@^2.0.1, svg.js@^2.2.5, svg.js@^2.4.0, svg.js@^2.6.5:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/svg.js/-/svg.js-2.7.1.tgz#eb977ed4737001eab859949b4a398ee1bb79948d"
+  integrity sha512-ycbxpizEQktk3FYvn/8BH+6/EuWXg7ZpQREJvgacqn46gIddG24tNNe4Son6omdXCnSOaApnpZw6MPCBA1dODA==
+
+svg.pathmorphing.js@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/svg.pathmorphing.js/-/svg.pathmorphing.js-0.1.3.tgz#c25718a1cc7c36e852ecabc380e758ac09bb2b65"
+  integrity sha512-49HWI9X4XQR/JG1qXkSDV8xViuTLIWm/B/7YuQELV5KMOPtXjiwH4XPJvr/ghEDibmLQ9Oc22dpWpG0vUDDNww==
+  dependencies:
+    svg.js "^2.4.0"
+
+svg.resize.js@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/svg.resize.js/-/svg.resize.js-1.4.3.tgz#885abd248e0cd205b36b973c4b578b9a36f23332"
+  integrity sha512-9k5sXJuPKp+mVzXNvxz7U0uC9oVMQrrf7cFsETznzUDDm0x8+77dtZkWdMfRlmbkEEYvUn9btKuZ3n41oNA+uw==
+  dependencies:
+    svg.js "^2.6.5"
+    svg.select.js "^2.1.2"
+
+svg.select.js@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/svg.select.js/-/svg.select.js-2.1.2.tgz#e41ce13b1acff43a7441f9f8be87a2319c87be73"
+  integrity sha512-tH6ABEyJsAOVAhwcCjF8mw4crjXSI1aa7j2VQR8ZuJ37H2MBUbyeqYr5nEO7sSN3cy9AR9DUwNg0t/962HlDbQ==
+  dependencies:
+    svg.js "^2.2.5"
+
+svg.select.js@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/svg.select.js/-/svg.select.js-3.0.1.tgz#a4198e359f3825739226415f82176a90ea5cc917"
+  integrity sha512-h5IS/hKkuVCbKSieR9uQCj9w+zLHoPh+ce19bBYyqF53g6mnPB8sAtIbe1s9dh2S2fCmYX2xel1Ln3PJBbK4kw==
+  dependencies:
+    svg.js "^2.6.5"
+
 svgo@^2.7.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-2.8.0.tgz#4ff80cce6710dc2795f0c7c74101e6764cfccd24"
@@ -6285,6 +6352,11 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
+vue-apexcharts@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/vue-apexcharts/-/vue-apexcharts-1.6.2.tgz#0547826067f97e8ea67ca9423e524eb6669746ad"
+  integrity sha512-9HS3scJwWgKjmkcWIf+ndNDR0WytUJD8Ju0V2ZYcjYtlTLwJAf2SKUlBZaQTkDmwje/zMgulvZRi+MXmi+WkKw==
+
 vue-eslint-parser@^8.0.0, vue-eslint-parser@^8.0.1:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-8.3.0.tgz#5d31129a1b3dd89c0069ca0a1c88f970c360bd0d"
@@ -6331,6 +6403,11 @@ vue-style-loader@4.1.3:
   dependencies:
     hash-sum "^1.0.2"
     loader-utils "^1.0.2"
+
+vue3-apexcharts@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/vue3-apexcharts/-/vue3-apexcharts-1.4.1.tgz#ea561308430a1c5213b7f17c44ba3c845f6c490d"
+  integrity sha512-96qP8JDqB9vwU7bkG5nVU+E0UGQn7yYQVqUUCLQMYWDuQyu2vE77H/UFZ1yI+hwzlSTBKT9BqnNG8JsFegB3eg==
 
 vue@^3.0.0:
   version "3.2.31"


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
Could probably benefit from having a local implementation and a SDK implementation. This one uses local, if there was an SDK endpoint for CPU stats then could add that as an option too. Perhaps pass a prop that specifies which to use. Obviously on a local network the local call will be quicker, but would be interesting to see what the response times are like between contacting the SDK which uses the Balena VPN to communicate, vs communicating directly around the world to a device which isn't behind a CDN. 