### PR TITLE
Only import ApexCharts when needed

### DIFF
--- a/ui/quasar.conf.js
+++ b/ui/quasar.conf.js
@@ -28,7 +28,7 @@ module.exports = configure(function (ctx) {
     // app boot file (/src/boot)
     // --> boot files are part of "main.js"
     // https://quasar.dev/quasar-cli/boot-files
-    boot: ['apexcharts', 'axios', 'i18n', 'system'],
+    boot: ['axios', 'i18n', 'system'],
 
     // https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-css
     css: ['app.scss'],

--- a/ui/src/boot/apexcharts.ts
+++ b/ui/src/boot/apexcharts.ts
@@ -1,7 +1,0 @@
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-import VueApexCharts from 'vue3-apexcharts'
-import { boot } from 'quasar/wrappers'
-
-export default boot(({ app }) => {
-  app.use(VueApexCharts)
-})

--- a/ui/src/components/charts/CpuStats.vue
+++ b/ui/src/components/charts/CpuStats.vue
@@ -22,7 +22,7 @@
   <div v-if="noData" class="text-center q-mb-md">
     {{ $t('charts.cpu_stats.no_data') }}
   </div>
-  <apexchart
+  <vue-apex-charts
     v-else
     :height="props.height"
     :options="chartOptions"
@@ -33,10 +33,10 @@
 <script lang="ts">
 import { AxiosResponse } from 'axios'
 import { expressApi } from 'boot/axios'
-import { getCssVar } from 'quasar'
+import { getCssVar, LoadingBar } from 'quasar'
 import { defineComponent, onMounted, onUnmounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { LoadingBar } from 'quasar'
+import VueApexCharts from 'vue3-apexcharts'
 
 interface cpuStat {
   data: {
@@ -54,6 +54,7 @@ interface series {
 
 export default defineComponent({
   name: 'IntCpuStats',
+  components: { VueApexCharts },
   props: {
     height: {
       type: Number,


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Keeping in line with the modular approach, charts are now only imported when the component with a chart in it is imported. This keeps the bundle size down if people do not use the device info component. 

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
