### PR TITLE
Switch tar for RSync in development environment

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,8 +1,6 @@
 # Build UI package
 FROM node:16.13.2-alpine3.15 as UI
 
-RUN apk add tar
-
 ENV NODE_ENV=development
 
 WORKDIR /build
@@ -13,17 +11,9 @@ COPY ui/yarn.lock yarn.lock
 # The network timeout prevents build timeouts when building on devices with slow SD cards
 RUN yarn install --network-timeout 600000 --frozen-lockfile
 
-# Copy app in to container
-COPY ui .
-
-# Pack all the node_module files
-RUN tar -cf /ui.tar --mode='a+rwX' .
-
 
 # Build ExpressJS package
 FROM node:16.13.2-alpine3.15 as ExpressJS
-
-RUN apk add tar
 
 ENV NODE_ENV=development
 
@@ -35,25 +25,23 @@ COPY expressjs/yarn.lock yarn.lock
 # The network timeout prevents build timeouts when building on devices with slow SD cards
 RUN yarn install --network-timeout 600000 --frozen-lockfile
 
-# Copy app in to container
-COPY expressjs .
-
-# Pack all the node_module files
-RUN tar -cf /expressjs.tar --mode='a+rwX' .
-
 
 ## Build environment
 FROM node:16.13.2-alpine3.15
 
-RUN apk add supervisor tar --no-cache
+RUN apk add rsync supervisor --no-cache
 
 ENV NODE_ENV=development
 
 WORKDIR /build
 
-# Copy packages into container
-COPY --from=ExpressJS /expressjs.tar .
-COPY --from=UI /ui.tar .
+# Copy node_modules into container
+COPY --from=ExpressJS /build dist/expressjs/
+COPY --from=UI /build dist/ui/
+
+# Copy app in to container
+COPY expressjs dist/expressjs/
+COPY ui dist/ui/
 
 # Copy the development sciprts required for launch
 COPY development .

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -46,5 +46,10 @@ COPY ui dist/ui/
 # Copy the development sciprts required for launch
 COPY development .
 
+# Used to identify whether a new build has been pushed and updates are required. Otherwise
+# a container reinstall by Supervisor could overwrite your changes to the files when the container
+# being installed hasn't changed. 
+RUN echo $(date +%s) > dist/.build_timestamp
+
 # Run the start script
 CMD ["sh", "start.sh"]

--- a/development/start.sh
+++ b/development/start.sh
@@ -2,13 +2,23 @@
 destination=/app/
 source=dist/
 
+destination_timestamp=$destination.build_timestamp
+source_timestamp=$source.build_timestamp
+
+start_time=$(date +%s)
+
 # Import env variables to container
 . .env_vars
 
 echo "Running in hot reload mode. Setting up the development environment..."
-start_time=$(date +%s)
 
-rsync --archive --delete --inplace $source $destination
+if [ -e "$destination_timestamp" ] && [ "$(cat ${destination_timestamp})" = "$(cat ${source_timestamp})" ]; then
+    echo "App is up to date."
+else
+    # Update volume with latest UI files
+    rsync --archive --delete --inplace $source $destination
+    echo "App updated."
+fi
 
 echo "Development environment ready. Setup took $(($(date +%s)-$start_time)) seconds."
 

--- a/development/start.sh
+++ b/development/start.sh
@@ -1,45 +1,16 @@
 #!/usr/bin/env
-
-expressjs_path=/app/expressjs/
-expressjs_tar=expressjs.tar
-
-ui_path=/app/ui/
-ui_tar=ui.tar
+destination=/app/
+source=dist/
 
 # Import env variables to container
 . .env_vars
 
-echo "Running in hot reload mode. Setting up the environment..."
+echo "Running in hot reload mode. Setting up the development environment..."
+start_time=$(date +%s)
 
-# Check if UI needs updating
-echo "Checking state of UI..."
-if tar --compare --file=$ui_tar --directory $ui_path &>/dev/null; then
-    echo "UI is up to date."
-else
-# Update volume with latest UI files
-    echo "Starting UI update..."
-    start_time=$(date +%s)
-    rm -rf $ui_path
-    mkdir -p $ui_path
-    tar xfp $ui_tar --directory $ui_path --atime-preserve
-    rm $ui_tar
-    echo "UI updated in $(($(date +%s)-$start_time)) seconds."
-fi
+rsync --archive --delete --inplace $source $destination
 
-# Check if ExpressJS needs updating
-echo "Checking state of ExpressJS..."
-if tar --compare --file=$expressjs_tar --directory $expressjs_path &>/dev/null; then
-    echo "ExpressJS is up to date."
-else
-# Update volume with latest ExpressJS files
-    echo "Starting ExpressJS update..."
-    start_time=$(date +%s)
-    rm -rf $expressjs_path
-    mkdir -p $expressjs_path
-    tar xfp $expressjs_tar --directory $expressjs_path --atime-preserve
-    rm $expressjs_tar
-    echo "ExpressJS updated in $(($(date +%s)-$start_time)) seconds."
-fi
+echo "Development environment ready. Setup took $(($(date +%s)-$start_time)) seconds."
 
-# Execute Supervisor
+# Start Supervisor
 exec supervisord -c supervisord.conf


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[X] Other, please explain:

**What changes did you make? (Give an overview)**
Switched from using tar files to RSync when populating the development environment

**Which issue (if any) does this pull request address?**
1. Faster build times as not needing to create TAR archives
2. Less writes to the card as it only works with files that changed or were deleted when putting new files on the device
3. Faster setup times on device for same reason as above
4. Simpler to see how it works in the shell files and Dockerfiles

**Is there anything you'd like reviewers to focus on?**
